### PR TITLE
Add iPro Create New Appointment Test Scripts

### DIFF
--- a/keywords/web/locators/ipro_locators.robot
+++ b/keywords/web/locators/ipro_locators.robot
@@ -1,0 +1,18 @@
+*** Variables ***
+# Login Page Locators
+${LOGIN_USERNAME_FIELD}       xpath=//input[@id='username' or @name='username']
+${LOGIN_PASSWORD_FIELD}       xpath=//input[@id='password' or @name='password' or @type='password']
+${LOGIN_BUTTON}               xpath=//button[contains(text(), 'Sign in') or contains(@class, 'login') or contains(@id, 'login')]
+${ROLE_DROPDOWN}              xpath=//select[@id='role' or contains(@id, 'roleSelector')] 
+
+# Dashboard Locators
+${HOT_LEAD_STATUS_FILTER}     xpath=//div[contains(text(), 'Hot Lead') or contains(@class, 'hot-lead')]
+${LEAD_ROW_BY_AGENT}          xpath=//tr[td[contains(text(), '{agent}')]]
+${LEAD_ITEM}                  xpath=//div[contains(@class, 'lead-item') and contains(., '{agent}')]
+
+# Side Menu Locators
+${SIDEBAR_VIRTUAL_VISIT}      xpath=//a[contains(text(), 'Virtual Site Visit') or contains(@href, 'virtual-site-visit')]
+
+# Appointment Locators
+${CREATE_APPOINTMENT_BUTTON}  xpath=//button[contains(text(), 'Create New Appointment') or contains(@id, 'create-appointment')]
+${APPOINTMENT_POPUP_TITLE}    xpath=//div[contains(@class, 'modal-title') and contains(text(), 'Create New Appointment')]

--- a/keywords/web/locators/virtual_site_visit_locators.robot
+++ b/keywords/web/locators/virtual_site_visit_locators.robot
@@ -1,0 +1,22 @@
+*** Variables ***
+# Login Page
+${USERNAME_FIELD}    input[type="text"]
+${PASSWORD_FIELD}    input[type="password"]
+${LOGIN_BUTTON}      button:nth-of-type(1)
+
+# Role Selection
+${ROLE_SELECTOR_BUTTON}    \#btn-role-select
+${TELE_RM_OPTION}          mat-option:nth-child(1)
+${CONFIRM_ROLE_BUTTON}     \#btn-confirm
+
+# Dashboard Page
+${HOT_LEAD_STATUS}          .status-hot-lead
+${HOT_LEAD_ROW}             .row.ng-star-inserted:has(.status-hot-lead)
+
+# Lead Detail Panel
+${VIRTUAL_SITE_VISIT_LINK}  .c-video-cam-icon
+
+# Virtual Site Visit Page
+${CREATE_NEW_APPOINTMENT_BUTTON}    button:contains("Create New Appointment")
+${APPOINTMENT_POPUP}               div.mat-dialog-container
+${APPOINTMENT_POPUP_TITLE}         h2:contains("Create New Appointment")

--- a/keywords/web/pages/ipro_page.robot
+++ b/keywords/web/pages/ipro_page.robot
@@ -1,0 +1,37 @@
+*** Settings ***
+Resource    ../../import.resource
+Resource    ../locators/ipro_locators.robot
+
+*** Keywords ***
+Login To iPro
+    [Arguments]    ${username}    ${password}    ${role}
+    Open Browser    ${URL}    ${BROWSER}
+    Maximize Browser Window
+    Wait Until Element Is Visible    ${LOGIN_USERNAME_FIELD}    timeout=30s
+    Input Text    ${LOGIN_USERNAME_FIELD}    ${username}
+    Input Text    ${LOGIN_PASSWORD_FIELD}    ${password}
+    Click Element    ${LOGIN_BUTTON}
+    
+    Wait Until Element Is Visible    ${ROLE_DROPDOWN}    timeout=30s
+    Select From List By Label    ${ROLE_DROPDOWN}    ${role}
+    
+Navigate To Hot Lead
+    [Arguments]    ${agent_name}
+    Wait Until Element Is Visible    ${HOT_LEAD_STATUS_FILTER}    timeout=30s
+    Click Element    ${HOT_LEAD_STATUS_FILTER}
+    
+    ${lead_row}=    Replace String    ${LEAD_ROW_BY_AGENT}    {agent}    ${agent_name}
+    Wait Until Element Is Visible    ${lead_row}
+    Click Element    ${lead_row}
+    
+Navigate To Virtual Site Visit
+    Wait Until Element Is Visible    ${SIDEBAR_VIRTUAL_VISIT}    timeout=30s
+    Click Element    ${SIDEBAR_VIRTUAL_VISIT}
+    
+Click Create New Appointment
+    Wait Until Element Is Visible    ${CREATE_APPOINTMENT_BUTTON}    timeout=30s
+    Click Element    ${CREATE_APPOINTMENT_BUTTON}
+    
+Verify Appointment Popup Is Displayed
+    Wait Until Element Is Visible    ${APPOINTMENT_POPUP_TITLE}    timeout=20s
+    Element Should Be Visible    ${APPOINTMENT_POPUP_TITLE}

--- a/keywords/web/pages/virtual_site_visit_page.robot
+++ b/keywords/web/pages/virtual_site_visit_page.robot
@@ -1,0 +1,52 @@
+*** Settings ***
+Resource    ../../import.resource
+Resource    ../locators/virtual_site_visit_locators.robot
+
+*** Keywords ***
+Login To Krungsri iPro
+    [Arguments]    ${username}    ${password}    ${role}=Tele RM
+    Open Browser    ${URL}    ${BROWSER}
+    Maximize Browser Window
+    Wait Until Element Is Visible    ${USERNAME_FIELD}
+    Input Text    ${USERNAME_FIELD}    ${username}
+    Input Password    ${PASSWORD_FIELD}    ${password}
+    Click Element    ${LOGIN_BUTTON}
+    
+    # Select role
+    Wait Until Element Is Visible    ${ROLE_SELECTOR_BUTTON}
+    Click Element    ${ROLE_SELECTOR_BUTTON}
+    Wait Until Element Is Visible    ${TELE_RM_OPTION}
+    Click Element    ${TELE_RM_OPTION}
+    Wait Until Element Is Enabled    ${CONFIRM_ROLE_BUTTON}
+    Click Element    ${CONFIRM_ROLE_BUTTON}
+    
+    # Verify dashboard loaded
+    Wait Until Page Contains    Dashboard
+
+Select Hot Lead With Current Agent
+    # Find and click on a row with "Hot Lead" status
+    Wait Until Page Contains Element    ${HOT_LEAD_STATUS}
+    ${count}=    Get Element Count    ${HOT_LEAD_STATUS}
+    IF    ${count} > 0
+        Click Element    ${HOT_LEAD_ROW}
+    ELSE
+        Fail    No Hot Lead entries found
+    END
+    
+    # Verify lead details panel opens
+    Wait Until Page Contains Element    ${VIRTUAL_SITE_VISIT_LINK}
+
+Navigate To Virtual Site Visit
+    Wait Until Element Is Visible    ${VIRTUAL_SITE_VISIT_LINK}
+    Click Element    ${VIRTUAL_SITE_VISIT_LINK}
+    
+    # Wait for Virtual Site Visit page to load
+    Wait Until Page Contains    Virtual Site Visit    timeout=10s
+
+Click Create New Appointment Button
+    Wait Until Element Is Visible    ${CREATE_NEW_APPOINTMENT_BUTTON}
+    Click Element    ${CREATE_NEW_APPOINTMENT_BUTTON}
+    
+    # Verify popup appears
+    Wait Until Element Is Visible    ${APPOINTMENT_POPUP}
+    Wait Until Page Contains Element    ${APPOINTMENT_POPUP_TITLE}

--- a/resources/setting/web/setting.yaml
+++ b/resources/setting/web/setting.yaml
@@ -1,2 +1,2 @@
 browser: chrome
-url: '' # TODO: Provide the URL for testing
+url: https://app-service-jao-dev.apps.ocp-test-bkk2.krungsri.net/web/dsl-dashboard

--- a/resources/setting/web/setting.yaml
+++ b/resources/setting/web/setting.yaml
@@ -1,2 +1,2 @@
 browser: chrome
-url: https://app-service-jao-dev.apps.ocp-test-bkk2.krungsri.net/web/dsl-dashboard
+url: 'https://app-service-jao-dev.apps.ocp-test-bkk2.krungsri.net/web/dsl-dashboard'

--- a/resources/testdata/web/ipro_data.yaml
+++ b/resources/testdata/web/ipro_data.yaml
@@ -1,0 +1,7 @@
+login:
+  username: "7N100342"
+  password: "P@ssw0rd"
+  role: "Tele RM"
+
+agent:
+  name: "7N100342"

--- a/testcase/web/ipro_create_new_appointment_ICNA001.robot
+++ b/testcase/web/ipro_create_new_appointment_ICNA001.robot
@@ -1,42 +1,40 @@
 *** Settings ***
-Documentation     Test case for creating a new appointment in Krungsri iPro system
-...               Case ID: ICNA001
-...               Reference: [iPro] Create New Appointment (UI): BIZLOAN-282
-...
-...               This test verifies that a user with Tele RM role can click on
-...               the Create New Appointment button and that the system displays
-...               the Create New Appointment popup.
-
-Resource          ../../keywords/web/common.robot
-Resource          ../../keywords/web/pages/ipro_page.robot
-
-Suite Setup       Setup Browser
-Test Setup        Login With Tele RM Role
-Test Teardown     Close All Browsers
+Documentation    Test case for creating new appointment in Krungsri iPro system
+...              Test Case: ICNA001 - User clicks on Create New Appointment
+...              BIZLOAN-282: [iPro] Create New Appointment (UI)
+Resource         ${CURDIR}/../../keywords/web/pages/virtual_site_visit_page.robot
+Suite Setup      Setup Environment
+Suite Teardown   Close All Browsers
+Test Teardown    Run Keyword If Test Failed    Capture Page Screenshot
 
 *** Variables ***
-${DATA_FILE}      ipro_data.yaml
+${URL}                https://app-service-jao-dev.apps.ocp-test-bkk2.krungsri.net/web/dsl-dashboard
+${USERNAME}           7N100342
+${PASSWORD}           P@ssw0rd
+${ROLE}               Tele RM
 
 *** Test Cases ***
 User Clicks On Create New Appointment
-    [Documentation]    Verify that user can click on Create New Appointment button
-    ...                and the system displays Create New Appointment popup.
-    [Tags]    regression    appointment    ICNA001    BIZLOAN-282
+    [Documentation]    Verify that clicking on Create New Appointment displays the popup
+    [Tags]            ICNA001    BIZLOAN-282    regression    ui
     
-    # Navigate to Hot Lead with current agent
-    Navigate To Hot Lead    ${TEST_DATA}[agent][name]
+    # Step 1: Sign in to the system
+    Login To Krungsri iPro    ${USERNAME}    ${PASSWORD}    ${ROLE}
     
-    # Navigate to Virtual Site Visit
+    # Step 2: Click on a lead with status 'Hot Lead' where current agent matches the user
+    Select Hot Lead With Current Agent
+    
+    # Step 3: Click Virtual Site Visit on side bar menu
     Navigate To Virtual Site Visit
     
-    # Click Create New Appointment button
-    Click Create New Appointment
+    # Step 4: Click on Create New Appointment button
+    Click Create New Appointment Button
     
-    # Verify that Create New Appointment popup is displayed
-    Verify Appointment Popup Is Displayed
-
+    # Verify the popup appears as expected
+    Page Should Contain    Create New Appointment
+    
 *** Keywords ***
-Login With Tele RM Role
-    ${TEST_DATA}=    Load Test Data    ${DATA_FILE}
-    Set Test Variable    ${TEST_DATA}
-    Login To iPro    ${TEST_DATA}[login][username]    ${TEST_DATA}[login][password]    ${TEST_DATA}[login][role]
+Setup Environment
+    # Setup Browser from common.robot
+    Set Selenium Implicit Wait    10
+    Set Selenium Timeout          30

--- a/testcase/web/ipro_create_new_appointment_ICNA001.robot
+++ b/testcase/web/ipro_create_new_appointment_ICNA001.robot
@@ -1,0 +1,42 @@
+*** Settings ***
+Documentation     Test case for creating a new appointment in Krungsri iPro system
+...               Case ID: ICNA001
+...               Reference: [iPro] Create New Appointment (UI): BIZLOAN-282
+...
+...               This test verifies that a user with Tele RM role can click on
+...               the Create New Appointment button and that the system displays
+...               the Create New Appointment popup.
+
+Resource          ../../keywords/web/common.robot
+Resource          ../../keywords/web/pages/ipro_page.robot
+
+Suite Setup       Setup Browser
+Test Setup        Login With Tele RM Role
+Test Teardown     Close All Browsers
+
+*** Variables ***
+${DATA_FILE}      ipro_data.yaml
+
+*** Test Cases ***
+User Clicks On Create New Appointment
+    [Documentation]    Verify that user can click on Create New Appointment button
+    ...                and the system displays Create New Appointment popup.
+    [Tags]    regression    appointment    ICNA001    BIZLOAN-282
+    
+    # Navigate to Hot Lead with current agent
+    Navigate To Hot Lead    ${TEST_DATA}[agent][name]
+    
+    # Navigate to Virtual Site Visit
+    Navigate To Virtual Site Visit
+    
+    # Click Create New Appointment button
+    Click Create New Appointment
+    
+    # Verify that Create New Appointment popup is displayed
+    Verify Appointment Popup Is Displayed
+
+*** Keywords ***
+Login With Tele RM Role
+    ${TEST_DATA}=    Load Test Data    ${DATA_FILE}
+    Set Test Variable    ${TEST_DATA}
+    Login To iPro    ${TEST_DATA}[login][username]    ${TEST_DATA}[login][password]    ${TEST_DATA}[login][role]


### PR DESCRIPTION
This PR adds automated test scripts for the iPro Create New Appointment functionality.

## Files Added
- Test case: `testcase/web/ipro_create_new_appointment_ICNA001.robot`
- Page object: `keywords/web/pages/ipro_page.robot`
- Locators: `keywords/web/locators/ipro_locators.robot`
- Test data: `resources/testdata/web/ipro_data.yaml`

## Test Case Information
- Case ID: ICNA001
- Reference: [iPro] Create New Appointment (UI): BIZLOAN-282
- Test verifies that a user with Tele RM role can click on the Create New Appointment button and that the system displays the Create New Appointment popup.

## Configuration
- Updated the web settings to point to the iPro system URL.